### PR TITLE
Comment out the inclusion of timestamps in compiled library

### DIFF
--- a/src/common/profiling.cpp
+++ b/src/common/profiling.cpp
@@ -347,7 +347,7 @@ void print_compilation_info()
 {
 #ifdef __GNUC__
     printf("g++ version: %s\n", __VERSION__);
-    printf("Compiled on %s %s\n", __DATE__, __TIME__);
+    //printf("Compiled on %s %s\n", __DATE__, __TIME__);
 #endif
 #ifdef STATIC
     printf("STATIC: yes\n");


### PR DESCRIPTION
This removes the one source of indeterminism that is preventing deterministic builds of Zcash.
